### PR TITLE
Remove odd evaluationProperty with int param

### DIFF
--- a/src/main/java/no/nav/fpsak/nare/evaluation/BasicEvaluation.java
+++ b/src/main/java/no/nav/fpsak/nare/evaluation/BasicEvaluation.java
@@ -53,7 +53,4 @@ public abstract class BasicEvaluation implements Evaluation {
         this.evaluationProperties.put(key, value);
     }
 
-    public void setEvaluationProperty(String key, int value) {
-        setEvaluationProperty(key, String.valueOf(value));
-    }
 }


### PR DESCRIPTION
Denne har vært brukt i ett inngangsvilkår for å sikre at det lagres et Vilkår med merknadParametere (som bare vil ha String)
Tenker det er greit å fjerne den for å unngå overraskelser ved at en int er blitt til String

@pekern  beregningsreglene putter mye BigDecimal og long inn i evaluationProperties - men ser ikke at man bruker dem i særlig grad