### PR TITLE
Fjern krav om kun Ja i sekvens, foreach

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ To model decision trees so they can be visualised, documented, and traced (input
 
 # Features
 * Unary expressions:
-  - Sequence
+  - Sequence: Sequence of expressions, result = result from last evaluation.
+  - Foreach:  
   - Not
   - Node:  (node computation supplied by implementor) Allows for arbitrary evaluations to be included.
 * Binary expressions:
   - And
   - Or
 * Ternary expressions:
-  - Conditional If/Else:  Allows for evaluating only specific subtrees based on a provided condition.
+* - Computational If/Else:  Simple if/then or if/then/else. Returns result from .
+* N-ary expressions:
+  - Conditional If/Or/Else:  Allows for evaluating only specific subtrees based on a provided condition.
 
 # Rule documentation
 The rule specification may be output to Asciidoc using the supplied Javadoc Doclet.  This will output names of parameters and rules to a single asciidoc document, while the trees will be output to a json document as a set of nodes and edges.  The output format in json is the same for both the specification and evaluation trees (except a few evaluation specific parameters), making both suitable for long term storage.

--- a/src/main/java/no/nav/fpsak/nare/Ruleset.java
+++ b/src/main/java/no/nav/fpsak/nare/Ruleset.java
@@ -2,6 +2,7 @@ package no.nav.fpsak.nare;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -21,16 +22,24 @@ public class Ruleset<V> {
         return specification.medBeskrivelse(beskrivelse).medID(id);
     }
 
+    public ConditionalOrSpecification.Builder<V> hvisRegel() {
+        return ConditionalOrSpecification.<V>regel();
+    }
+
     public ConditionalOrSpecification.Builder<V> hvisRegel(String id, String beskrivelse) {
         return ConditionalOrSpecification.<V>regel(id, beskrivelse);
+    }
+
+    public SequenceSpecification.Builder<V> sekvensRegel() {
+        return SequenceSpecification.<V>regel();
     }
 
     public SequenceSpecification.Builder<V> sekvensRegel(String id, String beskrivelse) {
         return SequenceSpecification.<V>regel(id, beskrivelse);
     }
 
-    public ComputationalIfSpecification.Builder<V> betingetSekvensRegel(Specification<V> hvis, Specification<V> evaluer) {
-        return ComputationalIfSpecification.<V>regel().hvis(hvis, evaluer);
+    public ComputationalIfSpecification.Builder<V> sekvensHvisRegel(Specification<V> hvis, Specification<V> evaluer) {
+        return ComputationalIfSpecification.<V>regel();
     }
 
     /**
@@ -84,6 +93,16 @@ public class Ruleset<V> {
 
     /**
      * Realiserer sekvens av N spesifikasjoner der bare den siste har betydning for videre flyt
+     *
+     * @param specs
+     * @return
+     */
+    public Specification<V> beregningsRegel(Specification<V>... specs) {
+        return new SequenceSpecification<>(Arrays.asList(specs));
+    }
+
+    /**
+     * Realiserer sekvens av N spesifikasjoner der bare den siste har betydning for videre flyt
      * 
      * @param id
      * @param beskrivelse
@@ -91,8 +110,7 @@ public class Ruleset<V> {
      * @param spec2
      * @return
      */
-    public Specification<V> beregningsRegel(String id, String beskrivelse, List<Specification<V>> spec1list,
-            Specification<V> spec2) {
+    public Specification<V> beregningsRegel(String id, String beskrivelse, List<Specification<V>> spec1list, Specification<V> spec2) {
         List<Specification<V>> specs = new ArrayList<>();
         specs.addAll(spec1list);
         specs.add(spec2);
@@ -117,6 +135,25 @@ public class Ruleset<V> {
             throw new IllegalArgumentException("Argumentlisten kan ikke være tom");
         }
         return new ForeachSpecification<>(id, beskrivelse, spec, args, argName);
+    }
+
+    /**
+     * Realiserer sekvens der en regel utføres N ganger - 1 gang for hvert element i en collection
+     *
+     * @param id
+     * @param beskrivelse
+     * @param spec          regel som utføres 1 gang for hvert element i argumentlisten, med argName + arg som "scope"
+     * @param argName
+     * @param args          argumentlisten, inneholder N argumenter
+     * @return
+     */
+    public Specification<V> beregningsForeachRegel(Specification<V> spec, String argName, List<?> args) {
+        Objects.requireNonNull(spec, "spec1");
+        Objects.requireNonNull(args, "args1");
+        if (args.isEmpty()) {
+            throw new IllegalArgumentException("Argumentlisten kan ikke være tom");
+        }
+        return new ForeachSpecification<>(spec, args, argName);
     }
 
     /**

--- a/src/main/java/no/nav/fpsak/nare/evaluation/node/ForeachEvaluation.java
+++ b/src/main/java/no/nav/fpsak/nare/evaluation/node/ForeachEvaluation.java
@@ -13,7 +13,7 @@ public class ForeachEvaluation extends AggregatedEvaluation {
 
     @Override
     public String reason() {
-        return "Utført " + ruleDescriptionText();
+        return "Utført " + lastChild().ruleIdentification();
     }
     
     @Override

--- a/src/main/java/no/nav/fpsak/nare/evaluation/summary/EvaluationSerializer.java
+++ b/src/main/java/no/nav/fpsak/nare/evaluation/summary/EvaluationSerializer.java
@@ -1,21 +1,19 @@
 package no.nav.fpsak.nare.evaluation.summary;
 
-import no.nav.fpsak.nare.doc.JsonOutput;
 import no.nav.fpsak.nare.doc.RuleDescriptionDigraph;
 import no.nav.fpsak.nare.evaluation.Evaluation;
+import no.nav.fpsak.nare.specification.Specification;
 
 public class EvaluationSerializer {
 
-    /**
-     * @deprecated Kun av historisk interesse. Bruk #asJson
-     */
-    @Deprecated
-    public static String asLegacyJsonTree(Evaluation evaluation) {
-        return JsonOutput.asJson(evaluation);
-    }
-    
     public static String asJson(Evaluation evaluation) {
-        RuleDescriptionDigraph digraph = new RuleDescriptionDigraph(evaluation.toRuleDescription());
+        var desc = evaluation.toRuleDescription();
+        RuleDescriptionDigraph digraph = new RuleDescriptionDigraph(desc);
+        return digraph.toJson();
+    }
+
+    public static String asJson(Specification<?> specification) {
+        RuleDescriptionDigraph digraph = new RuleDescriptionDigraph(specification.ruleDescription());
         return digraph.toJson();
     }
 

--- a/src/main/java/no/nav/fpsak/nare/specification/AbstractSpecification.java
+++ b/src/main/java/no/nav/fpsak/nare/specification/AbstractSpecification.java
@@ -1,6 +1,7 @@
 package no.nav.fpsak.nare.specification;
 
 import java.util.Map;
+import java.util.Optional;
 
 import no.nav.fpsak.nare.doc.JsonOutput;
 import no.nav.fpsak.nare.doc.RuleDescription;
@@ -89,5 +90,13 @@ public abstract class AbstractSpecification<T> implements Specification<T> {
     @Override
     public String toString() {
         return JsonOutput.asJson(this);
+    }
+
+    protected Optional<String> identifikatorIkkeTom () {
+        return Optional.ofNullable(id).filter(s -> !s.isEmpty());
+    }
+
+    protected Optional<String> beskrivelseIkkeTom () {
+        return Optional.ofNullable(beskrivelse).filter(s -> !s.isEmpty());
     }
 }

--- a/src/main/java/no/nav/fpsak/nare/specification/AndSpecification.java
+++ b/src/main/java/no/nav/fpsak/nare/specification/AndSpecification.java
@@ -16,12 +16,7 @@ public class AndSpecification<T> extends BinarySpecification<T> {
 
     @Override
     public String beskrivelse() {
-        String beskrivelse = super.beskrivelse();
-        if (beskrivelse.isEmpty()) {
-            return "(" + spec1.beskrivelse() + " OG " + spec2.beskrivelse() + ")";
-        } else {
-            return beskrivelse;
-        }
+        return beskrivelseIkkeTom().orElse("(OG)");
     }
 
     @Override
@@ -31,12 +26,7 @@ public class AndSpecification<T> extends BinarySpecification<T> {
 
     @Override
     public String identifikator() {
-        String id = super.identifikator();
-        if (id.isEmpty()) {
-            return "(" + spec1.identifikator() + " OG " + spec2.identifikator() + ")";
-        } else {
-            return id;
-        }
+        return identifikatorIkkeTom().orElseGet(() -> "(" + spec1.identifikator() + " OG " + spec2.identifikator() + ")");
     }
 
     @Override

--- a/src/main/java/no/nav/fpsak/nare/specification/ComputationalIfSpecification.java
+++ b/src/main/java/no/nav/fpsak/nare/specification/ComputationalIfSpecification.java
@@ -1,5 +1,7 @@
 package no.nav.fpsak.nare.specification;
 
+import java.util.Optional;
+
 import no.nav.fpsak.nare.ServiceArgument;
 import no.nav.fpsak.nare.doc.RuleDescription;
 import no.nav.fpsak.nare.evaluation.Evaluation;
@@ -31,6 +33,12 @@ public class ComputationalIfSpecification<T> extends AbstractSpecification<T> {
             this.testSpec = ifSpec;
             this.ifTrueSpec = thenSpec;
             return this;
+        }
+
+        public  ComputationalIfSpecification<T> hvisEllersJa(Specification<T> ifSpec, Specification<T> thenSpec) {
+            this.testSpec = ifSpec;
+            this.ifTrueSpec = thenSpec;
+            return this.build();
         }
 
         public ComputationalIfSpecification<T> ellers(Specification<T> specification) {
@@ -67,9 +75,14 @@ public class ComputationalIfSpecification<T> extends AbstractSpecification<T> {
         this.ifFalseSpec = ifFalseSpec;
     }
 
+    private Optional<Specification<T>> eller() {
+        return Optional.ofNullable(ifFalseSpec);
+    }
+
     @Override
     public String beskrivelse() {
-        return "...";
+        return beskrivelseIkkeTom()
+            .orElseGet(() -> "(COMP HVIS/SÅ" + eller().map(s -> "/ELLERS").orElse("") + ")");
     }
 
     @Override
@@ -108,12 +121,16 @@ public class ComputationalIfSpecification<T> extends AbstractSpecification<T> {
 
     @Override
     public String identifikator() {
-        return "...";
+        return identifikatorIkkeTom().orElseGet(() -> "(HVIS " + testSpec.identifikator() + " SÅ " + ifTrueSpec.identifikator() + eller().map(s -> " ELLERS " + s.identifikator()).orElse("") + ")");
     }
 
     @Override
     public RuleDescription ruleDescription() {
-        return new SpecificationRuleDescription(Operator.COMPUTATIONAL_IF, identifikator(), beskrivelse(), testSpec.ruleDescription(), ifTrueSpec.ruleDescription(), ifFalseSpec.ruleDescription());
+        if (ifFalseSpec != null) {
+            return new SpecificationRuleDescription(Operator.COMPUTATIONAL_IF, identifikator(), beskrivelse(), testSpec.ruleDescription(), ifTrueSpec.ruleDescription(), ifFalseSpec.ruleDescription());
+        } else {
+            return new SpecificationRuleDescription(Operator.COMPUTATIONAL_IF, identifikator(), beskrivelse(), testSpec.ruleDescription(), ifTrueSpec.ruleDescription());
+        }
     }
 
     @Override

--- a/src/main/java/no/nav/fpsak/nare/specification/ConditionalOrSpecification.java
+++ b/src/main/java/no/nav/fpsak/nare/specification/ConditionalOrSpecification.java
@@ -28,10 +28,12 @@ public class ConditionalOrSpecification<T> extends AbstractSpecification<T> {
     public static class Builder<T> {
         private final List<CondOrEntry<T>> conditionalEntries = new ArrayList<>();
         private Specification<T> elseCondition;
-        private String id;
-        private String beskrivelse;
+        private final String id;
+        private final String beskrivelse;
 
         public Builder() {
+            this.id = "";
+            this.beskrivelse = "";
         }
 
         public Builder(String id, String beskrivelse) {
@@ -108,6 +110,10 @@ public class ConditionalOrSpecification<T> extends AbstractSpecification<T> {
         }
     }
 
+    /*
+     * TODO: Vurder et binært/ternært expression-tree, som dette i realiteten er.
+     *  OBS: testSpec som eval til NEI kastes - tenk ikke-komplett regelsporing vs regelversjonering
+     */
     @Override
     public Evaluation evaluate(final T t) {
         AtomicReference<Evaluation> lastTestResult = new AtomicReference<>();
@@ -131,6 +137,24 @@ public class ConditionalOrSpecification<T> extends AbstractSpecification<T> {
         }
     }
 
+    @Override
+    public String identifikator() {
+        return identifikatorIkkeTom().orElseGet(() -> {
+            var condFirstEntry =  conditionalEntries.isEmpty() ? null : conditionalEntries.get(0);
+            var condId = condFirstEntry != null ? ("HVIS " + condFirstEntry.testSpec.identifikator() + " SÅ  ... ") : "";
+            var elseId = elseCondition != null ? ("ELLERS " + elseCondition.identifikator()) : "";
+            return "(COND " + condId + elseId + ")";
+        });
+    }
+
+    @Override
+    public String beskrivelse() {
+        return beskrivelseIkkeTom().orElse("(COND HVIS/SÅ/.../ELLERS)");
+    }
+
+    /*
+     * TODO: Vurder et binært expression-tree, som dette i realiteten er. Dessuten flyr det ikke for komplekse test-clauses
+     */
     @Override
     public RuleDescription ruleDescription() {
         var rootSpecId = identifikator();

--- a/src/main/java/no/nav/fpsak/nare/specification/ForeachSpecification.java
+++ b/src/main/java/no/nav/fpsak/nare/specification/ForeachSpecification.java
@@ -7,7 +7,6 @@ import no.nav.fpsak.nare.ServiceArgument;
 import no.nav.fpsak.nare.doc.RuleDescription;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.evaluation.Operator;
-import no.nav.fpsak.nare.evaluation.Resultat;
 import no.nav.fpsak.nare.evaluation.node.ForeachEvaluation;
 
 /**
@@ -19,26 +18,27 @@ public class ForeachSpecification<T> extends AbstractSpecification<T> {
     private List<?> args;
     private String argName;
 
-    public ForeachSpecification(String id, String beskrivelse, Specification<T> spec, List<?> args, String argName) {
+    public ForeachSpecification(Specification<T> spec, List<?> args, String argName) {
         super();
-        Objects.requireNonNull(id, "ID");
-        Objects.requireNonNull(beskrivelse, "beskrivelse");
         Objects.requireNonNull(spec, "spec");
         Objects.requireNonNull(args, "args");
         Objects.requireNonNull(argName, "argName");
         this.spec = spec;
         this.args = args;
         this.argName = argName;
+    }
+
+    public ForeachSpecification(String id, String beskrivelse, Specification<T> spec, List<?> args, String argName) {
+        this(spec, args, argName);
+        Objects.requireNonNull(id, "ID");
+        Objects.requireNonNull(beskrivelse, "beskrivelse");
         medID(id);
         medBeskrivelse(beskrivelse);
     }
 
     @Override
     public String beskrivelse() {
-        if (super.beskrivelse().isEmpty()) {
-            return "(FOREACH " + argName + ": " + spec.beskrivelse() + ")";
-        }
-        return super.beskrivelse();
+        return beskrivelseIkkeTom().orElseGet(() -> "(FOREACH " + argName + ")");
     }
 
     @Override
@@ -47,11 +47,7 @@ public class ForeachSpecification<T> extends AbstractSpecification<T> {
         Evaluation[] evaluations = new Evaluation[args.size()];
         for (var arg : args) {
             var serviceArgument = new ServiceArgument(argName, arg);
-            var eval = spec.evaluate(t, serviceArgument);
-            evaluations[ix] = eval;
-            if (!Resultat.JA.equals(evaluations[ix].result())) {
-                throw new IllegalArgumentException("Utviklerfeil: ForeachSpecification evaluering annet enn JA.");
-            }
+            evaluations[ix] = spec.evaluate(t, serviceArgument);
             ix++;
         }
         var resultingEval = new ForeachEvaluation(identifikator(), beskrivelse(), evaluations);
@@ -68,10 +64,7 @@ public class ForeachSpecification<T> extends AbstractSpecification<T> {
 
     @Override
     public String identifikator() {
-        if (super.identifikator().isEmpty()) {
-            return "(FOREACH " + argName + ": " + spec.beskrivelse() + ")";
-        }
-        return super.identifikator();
+        return identifikatorIkkeTom().orElseGet(() -> "(FOREACH " + argName + ": " + spec.identifikator() + ")");
     }
 
     @Override

--- a/src/main/java/no/nav/fpsak/nare/specification/NotSpecification.java
+++ b/src/main/java/no/nav/fpsak/nare/specification/NotSpecification.java
@@ -22,13 +22,7 @@ public class NotSpecification<T> extends AbstractSpecification<T> {
 
     @Override
     public String beskrivelse() {
-        String beskrivelse = super.beskrivelse();
-        if (beskrivelse.isEmpty()) {
-            return "(IKKE " + spec1.beskrivelse() + ")";
-        } else {
-            return beskrivelse;
-        }
-
+        return beskrivelseIkkeTom().orElse("(IKKE)");
     }
 
     @Override
@@ -38,12 +32,7 @@ public class NotSpecification<T> extends AbstractSpecification<T> {
 
     @Override
     public String identifikator() {
-        String id = super.identifikator();
-        if (id.isEmpty()) {
-            return "(IKKE " + spec1.identifikator() + ")";
-        } else {
-            return id;
-        }
+        return identifikatorIkkeTom().orElseGet(() -> "(IKKE " + spec1.identifikator() + ")");
     }
 
     @Override

--- a/src/main/java/no/nav/fpsak/nare/specification/OrSpecification.java
+++ b/src/main/java/no/nav/fpsak/nare/specification/OrSpecification.java
@@ -16,12 +16,7 @@ public class OrSpecification<T> extends BinarySpecification<T> {
 
     @Override
     public String beskrivelse() {
-        String beskrivelse = super.beskrivelse();
-        if (beskrivelse.isEmpty()) {
-            return "(" + spec1.beskrivelse() + " ELLER " + spec2.beskrivelse() + ")";
-        } else {
-            return beskrivelse;
-        }
+        return beskrivelseIkkeTom().orElse("(ELLER)");
     }
 
     @Override
@@ -31,12 +26,7 @@ public class OrSpecification<T> extends BinarySpecification<T> {
 
     @Override
     public String identifikator() {
-        String id = super.identifikator();
-        if (id.isEmpty()) {
-            return "(" + spec1.identifikator() + " ELLER " + spec2.identifikator() + ")";
-        } else {
-            return id;
-        }
+        return identifikatorIkkeTom().orElseGet(() -> "(" + spec1.identifikator() + " ELLER " + spec2.identifikator() + ")");
     }
 
     @Override

--- a/src/test/java/no/nav/fpsak/nare/specification/modrekvote/ModrekvoteConditionalOrSpecificationTest.java
+++ b/src/test/java/no/nav/fpsak/nare/specification/modrekvote/ModrekvoteConditionalOrSpecificationTest.java
@@ -29,9 +29,8 @@ public class ModrekvoteConditionalOrSpecificationTest {
 
         RuleService<Soknad> modrekvote = new ModrekvoteConditional();
         Evaluation evaluation = modrekvote.evaluer(soknad);
-        
-        @SuppressWarnings("deprecation")
-        String asJson = EvaluationSerializer.asLegacyJsonTree(evaluation);
+
+        String asJson = EvaluationSerializer.asJson(evaluation);
         EvaluationSummary evaluationSummary = new EvaluationSummary(evaluation);
         Collection<ModrekvoteUtfall> leafReasons = evaluationSummary.leafEvaluations(Resultat.NEI, Resultat.IKKE_VURDERT).stream()
                 .map(Evaluation::getOutcome)
@@ -49,7 +48,7 @@ public class ModrekvoteConditionalOrSpecificationTest {
         System.out.println(asJson);
         
         System.out.println("\n\n\n\n\n-------------\n\n\n");
-        System.out.println(EvaluationSerializer.asJson(evaluation));
+        System.out.println(EvaluationSerializer.asJson(modrekvote.getSpecification()));
     }
 
 }


### PR DESCRIPTION
* Fjern krav om kun Ja i sekvens, foreach
* Anonym sekvens mulig
* Flere builders
* EvaluationSummary: Metoder for å hente alle evalueringer under Sekvens/Foreach, ikke bare siste, pluss alle Outcomes.
* EvaluationSerializer: Støtte for å generere specification-digraph
* Rette feil ifm ConditionalOrSpecification-digraph