### PR TITLE
Enkelt oppsett for å generere/lese versjonsinfo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,5 +224,11 @@
                 </executions>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 </project>

--- a/src/main/java/no/nav/fpsak/nare/evaluation/summary/NareVersion.java
+++ b/src/main/java/no/nav/fpsak/nare/evaluation/summary/NareVersion.java
@@ -7,22 +7,19 @@ public class NareVersion {
     private NareVersion() {
     }
 
-    public static final EvaluationVersion NARE_VERSION = readProjectProperties(NareVersion.class.getClassLoader(), "nare");
+    public static final EvaluationVersion NARE_VERSION = readProjectProperties("nare", "nare/nare-version.properties");
 
 
-    public static EvaluationVersion readProjectProperties(ClassLoader cl, String defaultProjectName) {
-        String name;
+    public static EvaluationVersion readProjectProperties(String projectName, String propertiesFile) {
         String version;
         try {
             final Properties properties = new Properties();
-            properties.load(cl.getResourceAsStream("project.properties"));
-            name = properties.getProperty("name");
+            properties.load(NareVersion.class.getClassLoader().getResourceAsStream(propertiesFile));
             version = properties.getProperty("version");
         } catch (Exception e) {
-            name = defaultProjectName;
-            version = "0.0.0";
+            version = "UNKNOWN";
         }
-        return new EvaluationVersion(name, version);
+        return new EvaluationVersion(projectName, version);
     }
 
 }

--- a/src/main/java/no/nav/fpsak/nare/evaluation/summary/NareVersion.java
+++ b/src/main/java/no/nav/fpsak/nare/evaluation/summary/NareVersion.java
@@ -7,10 +7,10 @@ public class NareVersion {
     private NareVersion() {
     }
 
-    public static final EvaluationVersion NARE_VERSION = readProjectProperties("nare", "nare/nare-version.properties");
+    public static final EvaluationVersion NARE_VERSION = readVersionPropertyFor("nare", "nare/nare-version.properties");
 
 
-    public static EvaluationVersion readProjectProperties(String projectName, String propertiesFile) {
+    public static EvaluationVersion readVersionPropertyFor(String projectName, String propertiesFile) {
         String version;
         try {
             final Properties properties = new Properties();

--- a/src/main/java/no/nav/fpsak/nare/evaluation/summary/NareVersion.java
+++ b/src/main/java/no/nav/fpsak/nare/evaluation/summary/NareVersion.java
@@ -1,0 +1,28 @@
+package no.nav.fpsak.nare.evaluation.summary;
+
+import java.util.Properties;
+
+public class NareVersion {
+
+    private NareVersion() {
+    }
+
+    public static final EvaluationVersion NARE_VERSION = readProjectProperties(NareVersion.class.getClassLoader(), "nare");
+
+
+    public static EvaluationVersion readProjectProperties(ClassLoader cl, String defaultProjectName) {
+        String name;
+        String version;
+        try {
+            final Properties properties = new Properties();
+            properties.load(cl.getResourceAsStream("project.properties"));
+            name = properties.getProperty("name");
+            version = properties.getProperty("version");
+        } catch (Exception e) {
+            name = defaultProjectName;
+            version = "0.0.0";
+        }
+        return new EvaluationVersion(name, version);
+    }
+
+}

--- a/src/main/resources/nare/nare-version.properties
+++ b/src/main/resources/nare/nare-version.properties
@@ -1,2 +1,1 @@
-name=nare
 version=${project.version}

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,0 +1,2 @@
+name=nare
+version=${project.version}


### PR DESCRIPTION
Behovet er å kunne lese inn versjon av hhv nare, regelrepo m/semver, evt også app
Dette er ett av alternativene for å la maven generere versjonsinfo til nare/regelreponavn-version.properties og lese inn ditto. 
Navngivning Inspirert av kafka-clients/kafka-streams som bruker kafka/kafka-version.properties og kafka/kafka-streams-version-properties
Testet lokalt med nare-snapshot i uttak-regler og får opp ulike EvaluationVersion

Andre hovedalternativet er å generere MANIFEST.mf - men man må potensielt traversere en mengde av dem. Lesing fra pom.properties er ikke helt anbefalt.