### PR TITLE
chore: Jackson 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/no/nav/fpsak/nare/json/JsonOutput.java
+++ b/src/main/java/no/nav/fpsak/nare/json/JsonOutput.java
@@ -1,26 +1,27 @@
 package no.nav.fpsak.nare.json;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.cfg.EnumFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.TimeZone;
 
 public class JsonOutput {
 
-    private static final ObjectMapper MAPPER = createObjectMapper();
-
+    private static final JsonMapper MAPPER = createJsonMapperBuilder().build();
 
     private JsonOutput() {
+    }
+
+    public static JsonMapper getJsonMapper() {
+        return MAPPER;
     }
 
     public static String asJson(Object obj) {
         try {
             return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw mapException(obj, e);
         }
     }
@@ -28,26 +29,34 @@ public class JsonOutput {
     public static String asCompactJson(Object obj) {
         try {
             return MAPPER.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw mapException(obj, e);
         }
     }
 
-    private static NareJsonException mapException(Object obj, JsonProcessingException e) {
-        return new NareJsonException(String.format("Kunne ikke serialiseres til json: %s", obj), e);
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        try {
+            return MAPPER.readValue(json, clazz);
+        } catch (JacksonException e) {
+            throw mapException(json, e);
+        }
     }
 
-    private static ObjectMapper createObjectMapper() {
-        var om = new ObjectMapper();
-        om.registerModule(new JavaTimeModule());
-        om.registerModule(new Jdk8Module());
-        om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        om.setVisibility(PropertyAccessor.GETTER, Visibility.NONE);
-        om.setVisibility(PropertyAccessor.SETTER, Visibility.NONE);
-        om.setVisibility(PropertyAccessor.IS_GETTER, Visibility.NONE);
-        om.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-        om.setVisibility(PropertyAccessor.CREATOR, Visibility.ANY);
-        return om;
+    private static NareJsonException mapException(Object obj, JacksonException e) {
+        return new NareJsonException(String.format("Kunne ikke (de)serialiseres: %s", obj), e);
+    }
+
+    private static JsonMapper.Builder createJsonMapperBuilder() {
+        return JsonMapper.builder()
+                .defaultTimeZone(TimeZone.getTimeZone("Europe/Oslo"))
+                .disable(tools.jackson.databind.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES) // Var noen tester med null for booleans
+                .enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                .changeDefaultVisibility(v -> v
+                        .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                        .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                        .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                        .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                        .withCreatorVisibility(JsonAutoDetect.Visibility.ANY)
+                        .withScalarConstructorVisibility(JsonAutoDetect.Visibility.ANY));
     }
 }


### PR DESCRIPTION
Utkast til en versjon med Jackson 3. Fungerer sammen med andre regelrepos og fpsak.
Diskusjonstema: 
* Det er et pattern at mange regelbibliotek returnerer et Resultat med ferdig serialisert grunnlag, sporing, versjon + div
* JsonMapper nå og før tok med alle felt - også null / tomme
* Bør vi endre dette mønsteret slik at vi fjerner JsonMapper herfra og gjør toJson helt ute i fpsak/fpkalkulus? 
* Må i så fall se på bruk av mapper i div toString-implementasjoner 